### PR TITLE
feat: Add GNR-D as NIC Family in network enum

### DIFF
--- a/mfd_const/network.py
+++ b/mfd_const/network.py
@@ -28,6 +28,7 @@ class Family(Enum):
     CPK_SMBM = auto()
     CVL = auto()
     CNV = auto()
+    GNRD = auto()
     MEV = auto()
     NNTQ = auto()
     HVL = auto()
@@ -43,9 +44,12 @@ class Family(Enum):
 family_to_full_name = InternalDict(
     {
         Family.CVL: "Columbiaville",
+        Family.CPK: "Columbiapark",
         Family.FVL: "Fortville",
+        Family.FPK: "Fortpark",
         Family.CNV: "Connorsville",
         Family.LKV: "Linkville",
+        Family.GNRD: "Granite Rapids",
     }
 )
 
@@ -248,6 +252,10 @@ DEVICE_IDS = {
         "0x12D9",
         "0xF0A8",
     ],
+    Family.GNRD.name: [
+        "0x579C",
+        "0x579D",
+    ],
     Family.MEV.name: MEV_IDs,
     Family.NNTQ.name: ["0x1558"],
     Family.HVL.name: [
@@ -429,7 +437,7 @@ SPEED_IDS = {
     + DEVICE_IDS[Family.CVL.name]
     + DEVICE_IDS[Family.CNV.name]
     + DEVICE_IDS[Speed.VF_G100.value],
-    Speed.G200.value: DEVICE_IDS[Family.MEV.name],
+    Speed.G200.value: DEVICE_IDS[Family.MEV.name] + DEVICE_IDS[Family.GNRD.name],
 }
 
 FREEBSD_ADVERTISE_SPEED = {
@@ -639,7 +647,7 @@ DEVID_CLASS_MAP_NICINSTALLER = {
     ),
     "100G_CPK_SMBM": (DeviceID(0x188F), DeviceID(0x1895), DeviceID(0x0DCD)),
     "100G_VF": (DeviceID(0x18ED), DeviceID(0x1889), DeviceID(0x0DBD)),
-    "200G": (DeviceID(0xF002), DeviceID(0xF00C), DeviceID(0x1452)),
+    "200G": (DeviceID(0xF002), DeviceID(0xF00C), DeviceID(0x1452), DeviceID(0x579C), DeviceID(0x579D)),
 }
 
 DRIVER_DIRECTORY_MAP = {
@@ -662,6 +670,7 @@ DRIVER_DIRECTORY_MAP = {
     "ixl": "PRO40GB",
     "ixv": "PROXGB",
     "scea": "PROCCGB",
+    "sceb": "PROCCGB",
     "v1q": "PRO1000",
     "vx": "PROXGB",
 }
@@ -947,6 +956,10 @@ WINDOWS_DRIVER_DEVICE_ID_MAP = {
         DeviceID(0x579F),
         DeviceID(0xF0A5),
         DeviceID(0xF0A6),
+    },
+    "sceb": {
+        DeviceID(0x579C),
+        DeviceID(0x579D),
     },
 }
 

--- a/tests/unit/test_mfd_const/test_qos.py
+++ b/tests/unit/test_mfd_const/test_qos.py
@@ -2,23 +2,30 @@
 # SPDX-License-Identifier: MIT
 import mfd_const.qos as qos
 
+
 def test_local_ets_constant():
     assert qos.LOCAL_ETS == "ETS"
+
 
 def test_local_pfc_constant():
     assert qos.LOCAL_PFC == "PFC"
 
+
 def test_local_app_constant():
     assert qos.LOCAL_APP == "APP"
+
 
 def test_remote_ets_constant():
     assert qos.REMOTE_ETS == "Remote_ETS"
 
+
 def test_dcb_tool_path_lnx():
     assert qos.DCB_TOOL_PATH_LNX == r"/tmp/tools/dcb"
 
+
 def test_nic_registry_base_path_dcb():
     assert r"{4d36e972-e325-11ce-bfc1-08002be10318}" in qos.NIC_REGISTRY_BASE_PATH_DCB
+
 
 def test_local_default_map_structure():
     assert qos.LOCAL_ETS in qos.LOCAL_DEFAULT_MAP
@@ -27,11 +34,13 @@ def test_local_default_map_structure():
     assert isinstance(qos.LOCAL_DEFAULT_MAP[qos.LOCAL_PFC], list)
     assert len(qos.LOCAL_DEFAULT_MAP[qos.LOCAL_PFC]) == 8
 
+
 def test_local_iscsi_map_bandwidths():
     ets = qos.LOCAL_ISCSI_MAP[qos.LOCAL_ETS]
     assert ets["0"]["Bandwidth"] == 20
     assert ets["1"]["Bandwidth"] == 20
     assert ets["2"]["Bandwidth"] == 60
+
 
 def test_san_dcb_map_priorities():
     pfc = qos.SAN_DCB_MAP[qos.LOCAL_PFC]
@@ -39,11 +48,13 @@ def test_san_dcb_map_priorities():
     assert pfc[4] is True
     assert all(isinstance(val, bool) for val in pfc)
 
+
 def test_alt_san_dcb_app():
     app = qos.ALT_SAN_DCB[qos.LOCAL_APP]
     assert "3260" in app
     assert app["3260"]["Priority"] == 4
     assert app["3260"]["Protocol"] == "TCP"
+
 
 def test_iscsi_policy():
     assert "UP4" in qos.ISCSI_POLICY


### PR DESCRIPTION
This pull request adds support for the new `Granite Rapids` family (`GNRD`) to the `mfd_const/network.py` file. The changes update family definitions, device ID mappings, and speed associations to properly integrate `GNRD` into the network constants. Additionally, a small formatting update is made to the unit tests in `test_qos.py`.

Support for Granite Rapids family:

* Added `GNRD` to the `Family` enum and mapped its full name in the `family_to_full_name` dictionary. [[1]](diffhunk://#diff-0334596f222a158306cd631a93324fb539851b136af40b8d7dd6eaedad23c10eR31) [[2]](diffhunk://#diff-0334596f222a158306cd631a93324fb539851b136af40b8d7dd6eaedad23c10eR47-R52)
* Added device IDs for `GNRD` to the `DEVICE_IDS` mapping and included them in the `Speed.G200` device association. [[1]](diffhunk://#diff-0334596f222a158306cd631a93324fb539851b136af40b8d7dd6eaedad23c10eR255-R258) [[2]](diffhunk://#diff-0334596f222a158306cd631a93324fb539851b136af40b8d7dd6eaedad23c10eL432-R440)
* Updated the `"200G"` speed tuple to include `GNRD` device IDs.
* Added a new `"sceb"` device group containing `GNRD` device IDs.

Test file formatting:

* Added blank lines between test functions in `tests/unit/test_mfd_const/test_qos.py` for improved readability.